### PR TITLE
Fix the names in the bottom related posts section

### DIFF
--- a/_includes/page__meta.html
+++ b/_includes/page__meta.html
@@ -1,17 +1,17 @@
-{% assign authorCount = page.authors | size %}
+{% assign document = post | default: page %}
+{% assign authorCount = document.authors | size %}
 {% if authorCount == 0 %}
-  {% if page.author and site.data.authors[page.author] %}
-    {% assign author = site.data.authors[page.author] %}
+  {% if document.author and site.data.authors[document.author] %}
+    {% assign author = site.data.authors[document.author] %}
   {% else %}
     {% assign author = site.author %}
   {% endif %}
   
   {% assign authors = {{author.authorid | split: "," }} %}
 {% else %}
-  {% assign authors = page.authors %}
+  {% assign authors = document.authors %}
 {% endif %}
 
-{% assign document = post | default: page %}
 {% if document.read_time or document.show_date %}
   <p class="page__meta">
     <!-- new: add authors meta -->


### PR DESCRIPTION
This is a bug fix.


## Summary

The related posts section at the bottom of a blog post shows the wrong authors.
